### PR TITLE
Add a simple static API

### DIFF
--- a/src/site/static-api.page.ts
+++ b/src/site/static-api.page.ts
@@ -1,0 +1,33 @@
+interface BookInfo {
+    title: string
+    author: string
+    scheduledDate?: Date
+    ltid: string
+}
+
+interface BooksByLtid {
+    [key: string]: BookInfo
+}
+
+function byLtId(books: BookInfo[]): BooksByLtid {
+    return books.reduce((acc, book) => ({ ...acc, [book.ltid]: book }), {} as BooksByLtid)
+}
+
+export default function *staticApi({ search }: Lume.Data) {
+    const previousBooks = search.pages('previous')
+        .map(page => ({ title: page.title!, author: page.author, scheduledDate: page.date, ltid: page.ltid }))
+    const previousBooksByLtid = byLtId(previousBooks)
+    yield {
+        url: '/static-api/previous.json',
+        contentType: "application/json",
+        content: JSON.stringify(previousBooksByLtid)
+    }
+    const upcomingBooks = search.pages('upcoming')
+        .map(page => ({ title: page.title!, author: page.author, scheduledDate: page.scheduled ? page.date : undefined, ltid: page.ltid }))
+    const upcomingBooksByLtid = byLtId(upcomingBooks)
+    yield {
+        url: '/static-api/upcoming.json',
+        contentType: "application/json",
+        content: JSON.stringify(upcomingBooksByLtid)
+    }
+}


### PR DESCRIPTION
The dynamic API will need "database info" from the static site, so we build simple JSON files. Never under-estimate the simple API powers of statically generated JSON files.