### PR TITLE
Add an admin API to kickoff recounts

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -33,5 +33,5 @@ const app = new Hono<{ Variables: Variables }>()
     }
     return c.json({ success: true }, 200)
   })
-  
+
 export default app

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,37 @@
+import { bearerAuth } from 'hono/bearer-auth'
+import { getSessionByToken, type Session } from './models/session.ts'
+import type { KvProvidedVariables } from './kv.ts'
+import { Hono } from 'hono'
+import { queueRecountRequested } from './models/voting.ts'
+
+interface Variables extends KvProvidedVariables {
+  session: Session
+}
+
+const app = new Hono<{ Variables: Variables }>()
+  .use(
+    '/*',
+    bearerAuth({
+      verifyToken: async (token, c) => {
+        const kv = c.get('kv')
+        const session = await getSessionByToken(kv, token)
+        if (!session.success) {
+          return false
+        }
+        if (!session.data.admin) {
+          return false
+        }
+        c.set('session', session.data)
+        return true
+      },
+    }),
+  )
+  .post('/recount', async (c) => {
+    const result = await queueRecountRequested(c.get('kv'))
+    if (!result.ok) {
+      return c.json({ error: 'Failed to queue recount' }, 500)
+    }
+    return c.json({ success: true }, 200)
+  })
+  
+export default app

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import adminApp from './admin.ts'
 import inviteApp from './invite.ts'
 import loginApp from './login.ts'
 import userApp from './user.ts'
@@ -18,6 +19,7 @@ const app = new Hono<{ Variables: KvProvidedVariables }>()
     origin: ['https://worldmaker.net', 'http://localhost:3000'],
     allowHeaders: ['Authorization', 'Content-Type'],
   }))
+  .route('/admin', adminApp)
   .route('/invite', inviteApp)
   .route('/login', loginApp)
   .route('/user', userApp)

--- a/src/api/models/session.ts
+++ b/src/api/models/session.ts
@@ -4,6 +4,7 @@ import { UserId } from './user.ts'
 export const Session = z.object({
   token: z.string(),
   userId: UserId,
+  admin: z.boolean().optional(),
   expiresAt: z.coerce.date(),
 })
 


### PR DESCRIPTION
- Deno doesn't yet support enqueueing from the REPL connected to a remote KV
- Requires an admin session
- For now the only way to create/upgrade an admin session is from the Deno KV repl

A baby step towards #12