### PR TITLE
Add more OLIDs

### DIFF
--- a/src/site/_includes/book-card.vto
+++ b/src/site/_includes/book-card.vto
@@ -4,7 +4,7 @@
         <div class="media">
             {{ if olid }}
             <figure class="media-left">
-                <a href="https://openlibrary.org/works/{{ olid }}" class="image is-64x64">
+                <a href="https://openlibrary.org/books/{{ olid }}" class="image is-64x64">
                     <img src="https://covers.openlibrary.org/b/olid/{{ olid }}-S.jpg" alt="Thumbnail of cover of {{ title }} by {{ author }} from Open Library">
                 </a>
             </figure>

--- a/src/site/ballot/absolutely-remarkable-thing.md
+++ b/src/site/ballot/absolutely-remarkable-thing.md
@@ -2,7 +2,7 @@
 title: An Absolutely Remarkable Thing
 author: Hank Green
 ltid: '20576228'
-olid: OL19649395W
+olid: OL29806691M
 tags: [boat]
 ---
 

--- a/src/site/ballot/ancillary-justice.md
+++ b/src/site/ballot/ancillary-justice.md
@@ -2,6 +2,7 @@
 title: Ancillary Justice
 author: Ann Leckie
 ltid: '14046991'
+olid: OL25631969M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/animorphs-1-the-invasion.md
+++ b/src/site/ballot/animorphs-1-the-invasion.md
@@ -2,6 +2,7 @@
 id: 01JN03XDJ49XYAQ3QGG5NN8P8J
 userId: 01JJ2XCD6C339ZW7CBC4Y8HSAK
 ltid: '252467'
+olid: OL24935064M
 title: 'Animorphs #1: The Invasion'
 author: K. A. Applegate
 whyBlurb: >-

--- a/src/site/ballot/atrocity-archives.md
+++ b/src/site/ballot/atrocity-archives.md
@@ -2,6 +2,7 @@
 title: The Atrocity Archives
 author: Charles Stross
 ltid: '23298'
+olid: OL3679911M
 tags: [scifi, horror]
 ---
 

--- a/src/site/ballot/babel.md
+++ b/src/site/ballot/babel.md
@@ -2,6 +2,7 @@
 title: "Babel: Or the Necessity of Violence: An Arcane History of the Oxford Translators' Revolution"
 author: R. F. Kuang
 ltid: '27418541'
+olid: OL36541099M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/beasts-prey.md
+++ b/src/site/ballot/beasts-prey.md
@@ -2,6 +2,7 @@
 title: Beasts of Prey
 author: Ayana Gray
 ltid: '25813695'
+olid: OL36925792M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/book-unnamed-midwife.md
+++ b/src/site/ballot/book-unnamed-midwife.md
@@ -2,7 +2,7 @@
 title: The Book of the Unnamed Midwife
 author: Meg Elison
 ltid: '15096895'
-olid: OL19757909W
+olid: OL26970943M
 tags: [boat]
 ---
 

--- a/src/site/ballot/butcher-forest.md
+++ b/src/site/ballot/butcher-forest.md
@@ -2,6 +2,7 @@
 title: The Butcher of the Forest
 author: Premee Mohamed
 ltid: '30442305'
+olid: OL50623911M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/children-time.md
+++ b/src/site/ballot/children-time.md
@@ -2,6 +2,7 @@
 title: Children of Time
 author: Adrian Tchaikovsky
 ltid: '16049191'
+olid: OL27322146M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/city-brass.md
+++ b/src/site/ballot/city-brass.md
@@ -2,6 +2,7 @@
 title: The City of Brass
 author: S. A. Chakraborty
 ltid: '19640942'
+olid: OL28843098M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/clean-sweep.md
+++ b/src/site/ballot/clean-sweep.md
@@ -2,6 +2,7 @@
 title: Clean Sweep
 author: Ilona Andrews
 ltid: '13177969'
+olid: OL32047841M
 tags: [scifi, fantasy]
 ---
 

--- a/src/site/ballot/curse-chalion.md
+++ b/src/site/ballot/curse-chalion.md
@@ -2,6 +2,7 @@
 title: The Curse of Chalion
 author: Lois McMaster Bujold
 ltid: '7337'
+olid: OL47129749M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/end-everything.md
+++ b/src/site/ballot/end-everything.md
@@ -2,6 +2,7 @@
 title: The End of Everything (Astrophysically Speaking)
 author: Katie Mack
 ltid: '24122920'
+olid: OL29837371M
 tags: [non-fiction]
 ---
 

--- a/src/site/ballot/every-heart-doorway.md
+++ b/src/site/ballot/every-heart-doorway.md
@@ -2,6 +2,7 @@
 title: Every Heart a Doorway
 author: Seanan McGuire
 ltid: '15998723'
+olid: OL29720583M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/first-fifteen-lives-harry-august.md
+++ b/src/site/ballot/first-fifteen-lives-harry-august.md
@@ -2,6 +2,7 @@
 title: The First Fifteen Lives of Harry August
 author: Claire North
 ltid: '14297982'
+olid: OL28227679M
 tags: [romance, scifi]
 ---
 

--- a/src/site/ballot/foundation.md
+++ b/src/site/ballot/foundation.md
@@ -2,6 +2,7 @@
 title: Foundation
 author: Isaac Asimov
 ltid: '3116747'
+olid: OL51566464M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/grass.md
+++ b/src/site/ballot/grass.md
@@ -2,6 +2,7 @@
 title: Grass
 author: Sheri Tepper
 ltid: '20786'
+olid: OL22916842M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/hands-emperor.md
+++ b/src/site/ballot/hands-emperor.md
@@ -2,6 +2,7 @@
 title: The Hands of the Emperor
 author: Victoria Goddard
 ltid: '23023728'
+olid: OL27771338M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/harrow-ninth.md
+++ b/src/site/ballot/harrow-ninth.md
@@ -2,6 +2,7 @@
 title: Harrow the Ninth
 author: Tamsyn Muir
 ltid: '23694338'
+olid: OL29831093M
 tags: [fantasy, horror]
 ---
 

--- a/src/site/ballot/hellspark.md
+++ b/src/site/ballot/hellspark.md
@@ -2,6 +2,7 @@
 title: Hellspark
 author: Janet Kagan
 ltid: '42793'
+olid: OL6896101M
 tags: [scifi, horror, mystery]
 ---
 

--- a/src/site/ballot/invisible-life-addie-larue.md
+++ b/src/site/ballot/invisible-life-addie-larue.md
@@ -2,6 +2,7 @@
 title: The Invisible Life of Addie LaRue
 author: V. E. Schwab
 ltid: '27450296'
+olid: OL38123862M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/lies-locke-lamora.md
+++ b/src/site/ballot/lies-locke-lamora.md
@@ -2,6 +2,7 @@
 title: The Lies of Locke Lamora
 author: Scott Lynch
 ltid: '797435'
+olid: OL15987639M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/lost-ark-dreaming.md
+++ b/src/site/ballot/lost-ark-dreaming.md
@@ -2,6 +2,7 @@
 title: Lost Ark Dreaming
 author: Suyi Davies Okungbowa
 ltid: '31363262'
+olid: OL50733836M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/lovecraft-country.md
+++ b/src/site/ballot/lovecraft-country.md
@@ -2,6 +2,7 @@
 title: Lovecraft Country
 author: Matt Ruff
 ltid: '15800813'
+olid: OL25933909M
 tags: [horror]
 ---
 

--- a/src/site/ballot/marvellous-light.md
+++ b/src/site/ballot/marvellous-light.md
@@ -2,6 +2,7 @@
 title: A Marvellous Light
 author: Freya Marske
 ltid: '24656599'
+olid: OL37993952M
 tags: [fantasy, romance]
 ---
 

--- a/src/site/ballot/memory-called-empire.md
+++ b/src/site/ballot/memory-called-empire.md
@@ -2,6 +2,7 @@
 title: A Memory Called Empire
 author: Arkady Martine
 ltid: '21852517'
+olid: OL29792700M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/mistborn.md
+++ b/src/site/ballot/mistborn.md
@@ -2,6 +2,7 @@
 title: 'Mistborn: The Final Empire'
 author: Brandon Sanderson
 ltid: '1287660'
+olid: OL27959083M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/nettle-and-bone.md
+++ b/src/site/ballot/nettle-and-bone.md
@@ -2,6 +2,7 @@
 id: 01JP3WVT7G2J0MC7042G1KH8FP
 userId: 01JMT7410J2ZV5QA3FFNRXZ579
 ltid: '26196827'
+olid: OL34158510M
 title: Nettle and Bone
 author: T. Kingfisher
 whyBlurb: >-

--- a/src/site/ballot/nights-master.md
+++ b/src/site/ballot/nights-master.md
@@ -2,6 +2,7 @@
 id: 01JN6XPPDXEPMQNYNWQPSDKJ3Z
 userId: 01JJ2XCD6C339ZW7CBC4Y8HSAK
 ltid: '149937'
+olid: OL8195581M
 title: Night's Master
 author: Tanith Lee
 whyBlurb: >-

--- a/src/site/ballot/ninth-house.md
+++ b/src/site/ballot/ninth-house.md
@@ -2,6 +2,7 @@
 title: Ninth House
 author: Leigh Bardugo
 ltid: '18592605'
+olid: OL27384618M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/peripheral.md
+++ b/src/site/ballot/peripheral.md
@@ -2,6 +2,7 @@
 title: The Peripheral
 author: William Gibson
 ltid: '14850872'
+olid: OL27176668M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/project-hail-mary.md
+++ b/src/site/ballot/project-hail-mary.md
@@ -2,6 +2,7 @@
 title: Project Hail Mary
 author: Andy Weir
 ltid: '25215827'
+olid: OL38627505M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/ring-shout.md
+++ b/src/site/ballot/ring-shout.md
@@ -2,6 +2,7 @@
 title: Ring Shout
 author: P. Djèlí Clark
 ltid: '24213124'
+olid: OL34085306M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/some-desperate-glory.md
+++ b/src/site/ballot/some-desperate-glory.md
@@ -2,6 +2,7 @@
 title: Some Desperate Glory
 author: Emily Tesh
 ltid: '26911573'
+olid: OL51158440M
 tags: [scifi]
 ---
 

--- a/src/site/ballot/sunshine.md
+++ b/src/site/ballot/sunshine.md
@@ -2,6 +2,7 @@
 title: Sunshine
 author: Robin McKinley
 ltid: '10635'
+olid: OL3687463M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/thistlefoot.md
+++ b/src/site/ballot/thistlefoot.md
@@ -2,6 +2,7 @@
 title: Thistlefoot
 author: GennaRose Nethercott
 ltid: '27998898'
+olid: OL46619640M
 tags: [fantasy]
 ---
 

--- a/src/site/ballot/under-whispering-door.md
+++ b/src/site/ballot/under-whispering-door.md
@@ -2,6 +2,7 @@
 title: Under the Whispering Door
 author: TJ Klune
 ltid: '24876955'
+olid: OL29891356M
 tags: [fantasy]
 ---
 

--- a/src/site/held/adventures-amina-al-sirafi.md
+++ b/src/site/held/adventures-amina-al-sirafi.md
@@ -2,6 +2,7 @@
 title: The Adventures of Amina al-Sirafi
 author: Shannon Chakraborty
 ltid: '28346417'
+olid: OL38927230M
 tags: [fantasy]
 ---
 

--- a/src/site/held/good-omens.md
+++ b/src/site/held/good-omens.md
@@ -2,6 +2,7 @@
 title: 'Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch'
 author: Neil Gaiman and Terry Pratchett
 ltid: '5794'
+olid: OL27102163M
 tags: [fantasy]
 ---
 

--- a/src/site/held/martian.md
+++ b/src/site/held/martian.md
@@ -2,6 +2,7 @@
 title: The Martian
 author: Andy Weir
 ltid: '13265773'
+olid: OL32815550M
 tags: [scifi]
 ---
 

--- a/src/site/held/red-mars.md
+++ b/src/site/held/red-mars.md
@@ -2,6 +2,7 @@
 title: Red Mars
 author: Kim Stanley Robinson
 ltid: '17666'
+olid: OL21441703M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2022-11-12-goblin-emperor.md
+++ b/src/site/previous/2022-11-12-goblin-emperor.md
@@ -2,6 +2,7 @@
 title: The Goblin Emperor
 author: Katherine Addison
 ltid: '14133665'
+olid: OL25843813M
 tags: [fantasy]
 ---
 

--- a/src/site/previous/2023-01-28-city-we-became.md
+++ b/src/site/previous/2023-01-28-city-we-became.md
@@ -2,6 +2,7 @@
 title: The City We Became
 author: NK Jemison
 ltid: '22696102'
+olid: OL27931136M
 tags: [boat, fantasy]
 ---
 

--- a/src/site/previous/2023-03-06-kaiju.md
+++ b/src/site/previous/2023-03-06-kaiju.md
@@ -2,6 +2,7 @@
 title: The Kaiju Preservation Society
 author: John Scalzi
 ltid: '26638244'
+olid: OL32212076M
 tags: [boat, scifi]
 ---
 

--- a/src/site/previous/2023-04-23-gideon-ninth.md
+++ b/src/site/previous/2023-04-23-gideon-ninth.md
@@ -2,6 +2,7 @@
 title: Gideon the Ninth
 author: Tamsyn Muir
 ltid: '21635641'
+olid: OL27308126M
 tags: [fantasy, horror]
 ---
 

--- a/src/site/previous/2023-06-25-long-way.md
+++ b/src/site/previous/2023-06-25-long-way.md
@@ -2,6 +2,7 @@
 title: The Long Way to a Small, Angry Planet
 author: Becky Chambers
 ltid: '15424391'
+olid: OL26318316M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2023-08-20-all-systems-red.md
+++ b/src/site/previous/2023-08-20-all-systems-red.md
@@ -2,6 +2,7 @@
 title: All Systems Red
 author: Martha Wells
 ltid: '18809896'
+olid: OL26818660M
 tags: [boat, scifi]
 ---
 

--- a/src/site/previous/2023-10-08-defensive-baking.md
+++ b/src/site/previous/2023-10-08-defensive-baking.md
@@ -2,6 +2,7 @@
 title: A Wizard's Guide to Defensive Baking
 author: T. Kingfisher
 ltid: '25043567'
+olid: OL28348763M
 tags: [boat, fantasy]
 ---
 

--- a/src/site/previous/2023-11-19-legends-lattes.md
+++ b/src/site/previous/2023-11-19-legends-lattes.md
@@ -2,6 +2,7 @@
 title: Legends and Lattes
 author: Travis Baldree
 ltid: '27661802'
+olid: OL38791112M
 tags: [fantasy]
 ---
 

--- a/src/site/previous/2024-01-20-camp-damascus.md
+++ b/src/site/previous/2024-01-20-camp-damascus.md
@@ -2,6 +2,7 @@
 title: Camp Damascus
 author: Chuck Tingle
 ltid: '29454979'
+olid: OL50706568M
 tags: [horror]
 ---
 

--- a/src/site/previous/2024-03-30-deadly-education.md
+++ b/src/site/previous/2024-03-30-deadly-education.md
@@ -2,6 +2,7 @@
 title: A Deadly Education
 author: Naomi Novik
 ltid: '24218299'
+olid: OL29514724M
 tags: [fantasy]
 ---
 

--- a/src/site/previous/2024-05-11-spare-man.md
+++ b/src/site/previous/2024-05-11-spare-man.md
@@ -2,6 +2,7 @@
 title: The Spare Man
 author: Mary Robinette Kowal
 ltid: '23117595'
+olid: OL35034824M
 tags: [boat, scifi, mystery]
 ---
 

--- a/src/site/previous/2024-07-14-light-uncommon-stars.md
+++ b/src/site/previous/2024-07-14-light-uncommon-stars.md
@@ -2,6 +2,7 @@
 title: Light from Uncommon Stars
 author: Ryka Aoki
 ltid: '25821771'
+olid: OL34158509M
 tags: [boat, scifi, fantasy]
 ---
 

--- a/src/site/previous/2024-09-07-tomorrow-tomorrow-tomorrow.md
+++ b/src/site/previous/2024-09-07-tomorrow-tomorrow-tomorrow.md
@@ -2,6 +2,7 @@
 title: Tomorrow and Tomorrow and Tomorrow
 author: Gabrielle Zevin
 ltid: '27351724'
+olid: OL51804378M
 ---
 
 Blurbs from JoCoNauts:

--- a/src/site/previous/2024-11-09-space-opera.md
+++ b/src/site/previous/2024-11-09-space-opera.md
@@ -2,6 +2,7 @@
 title: Space Opera
 author: Cat Valente
 ltid: '19728454'
+olid: OL27349809M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2025-01-05-how-you-lose-time-war.md
+++ b/src/site/previous/2025-01-05-how-you-lose-time-war.md
@@ -2,6 +2,7 @@
 title: This is How You Lose the Time War
 author: Amal El-Mohtar and Max Gladstone
 ltid: '21713349'
+olid: OL27901088M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2025-02-23-axioms-end.md
+++ b/src/site/previous/2025-02-23-axioms-end.md
@@ -2,6 +2,7 @@
 title: "Axiom's End"
 author: Lindsay Ellis
 ltid: '23821128'
+olid: OL32601440M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2025-05-04-binti.md
+++ b/src/site/previous/2025-05-04-binti.md
@@ -2,6 +2,7 @@
 title: 'Binti: The Complete Trilogy'
 author: Nnedi Okorafor
 ltid: '22496438'
+olid: OL26869506M
 tags: [scifi]
 ---
 

--- a/src/site/previous/2025-06-28-fifth-season.md
+++ b/src/site/previous/2025-06-28-fifth-season.md
@@ -2,6 +2,7 @@
 title: The Fifth Season
 author: N. K. Jemisin
 ltid: '14231634'
+olid: OL25941433M
 tags: [boat, scifi]
 ---
 

--- a/src/site/previous/2025-08-16-years-rice-salt.md
+++ b/src/site/previous/2025-08-16-years-rice-salt.md
@@ -2,6 +2,7 @@
 title: The Years of Rice and Salt
 author: Kim Stanley Robinson
 ltid: '23185'
+olid: OL3950670M
 tags: [fantasy]
 ---
 

--- a/src/site/upcoming/2025-10-04-princess-bride.md
+++ b/src/site/upcoming/2025-10-04-princess-bride.md
@@ -2,7 +2,7 @@
 title: The Princess Bride
 author: William Goldman
 ltid: '4936'
-olid: OL486967W
+olid: OL3704385M
 tags: [fantasy]
 scheduled: true
 ---


### PR DESCRIPTION
The trick to the OLIDs seems to be that to get a cover display we need an Edition Identifier (usually ending in "M") rather than a Work Identifier (usually ending in a "W").

Resolves #46