### PR TITLE
Add a "Common Fiction" tag

### DIFF
--- a/src/bf/suggestion-editor/form.tsx
+++ b/src/bf/suggestion-editor/form.tsx
@@ -309,7 +309,9 @@ export function Form(
         <p class='help'>
           Optionally select all relevant genres for this suggestion. "Boat"
           means the author has attended at least one JoCo Cruise. For the rest,
-          use your best judgment, because the definitions are subjective
+          use your best judgment, because the definitions are subjective, and
+          "Common Fiction" is useful for anything that isn't more strongly the
+          other genres
         </p>
       </div>
       <div class='field is-grouped'>

--- a/src/site/_data/genre/tags.json
+++ b/src/site/_data/genre/tags.json
@@ -3,6 +3,7 @@
     "iconClass": "has-text-info",
     "icon": "fa-ship-large",
     "title": "Authors of the Cruise",
+    "description": "Books by authors who have sailed with JoCo Cruise at least once",
     "name": "Boat",
     "tagClass": "is-info",
     "tagIconClass": ""
@@ -48,5 +49,13 @@
     "title": "Non-Fiction",
     "tagClass": "is-dark",
     "tagIconClass": "has-text-info"
+  },
+  "common": {
+    "iconClass": "has-text-warning",
+    "icon": "fa-book-section",
+    "title": "Common Fiction",
+    "description": "Books generally outside of the other main genres, often with a mainstream appeal.",
+    "tagClass": "is-warning",
+    "tagIconClass": ""
   }
 }

--- a/src/site/_includes/tag.vto
+++ b/src/site/_includes/tag.vto
@@ -8,6 +8,9 @@ bfscript: /bf/tag-page.js
         <span class="icon {{iconClass}}"><i class="fa-duotone fa-solid {{icon}}"></i></span>
         <span>{{title}}</span>
     </h1>
+    {{ if description }}
+    <h2 class="subtitle">{{description}}</h2>
+    {{ /if }}
     <tag-tally-top5 tag="{{tag}}">
         <p>You will need to have JS enabled and to login to see the current rankings.</p>
     </tag-tally-top5>

--- a/src/site/ballot/overstory.md
+++ b/src/site/ballot/overstory.md
@@ -2,6 +2,7 @@
 title: The Overstory
 author: Richard Powers
 ltid: '20296983'
+tags: [common]
 ---
 
 Blurb from a JoCoNaut:

--- a/src/site/previous/2024-09-07-tomorrow-tomorrow-tomorrow.md
+++ b/src/site/previous/2024-09-07-tomorrow-tomorrow-tomorrow.md
@@ -3,6 +3,7 @@ title: Tomorrow and Tomorrow and Tomorrow
 author: Gabrielle Zevin
 ltid: '27351724'
 olid: OL51804378M
+tags: [common]
 ---
 
 Blurbs from JoCoNauts:


### PR DESCRIPTION
"Common Fiction" is like buying TCG booster packs, the other genres are more rare and sparkle more, but sometimes you really need to fill your deck with all the common lands to properly balance your attack engine.