### PR TITLE
Use the full powers of the Bulma navbar

### DIFF
--- a/src/bf/_build.ts
+++ b/src/bf/_build.ts
@@ -9,11 +9,8 @@ await esbuild.build({
     { out: 'book-page', in: './pages/book.ts' },
     { out: 'final-tally', in: './final-tally/main.tsx' },
     { out: 'invite-register', in: './invite-register/main.tsx' },
-    {
-      out: 'login-button',
-      in: './login-button/main.tsx',
-    },
     { out: 'login-form', in: './login-form/main.tsx' },
+    { out: 'nav-menu', in: './nav-menu.ts' },
     { out: 'passkey-page', in: './pages/passkey.ts' },
     { out: 'suggestions-page', in: './pages/suggestions.ts' },
     { out: 'tag-page', in: './pages/tag.ts' },

--- a/src/bf/nav-menu.ts
+++ b/src/bf/nav-menu.ts
@@ -1,0 +1,24 @@
+export * from './login-button/main.tsx'
+
+export class NavMenu extends HTMLElement {
+  #burger: HTMLElement | null = null
+  #menu: HTMLElement | null = null
+
+  onBurgerClick = () => {
+    this.#burger?.classList.toggle('is-active')
+    this.#menu?.classList.toggle('is-active')
+  }
+
+  connectedCallback() {
+    this.#burger = this.querySelector('.navbar-burger')
+    this.#menu = this.querySelector('.navbar-menu')
+    if (this.#burger) {
+      this.#burger.addEventListener('click', this.onBurgerClick)
+    }
+  }
+
+  disconnectedCallback() {
+    this.#burger?.removeEventListener('click', this.onBurgerClick)
+  }
+}
+customElements.define('nav-menu', NavMenu)

--- a/src/site/_includes/main.vto
+++ b/src/site/_includes/main.vto
@@ -10,37 +10,87 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
         <link rel="stylesheet" href="{{ "/assets/bookclub.css" |> url }}">
         <script src="https://kit.fontawesome.com/3b41ac7e32.js" crossorigin="anonymous"></script>
-        <script type="module" src="/bf/login-button.js"></script>
+        <script type="module" src="/bf/nav-menu.js"></script>
         {{ if bfscript }}
         <script type="module" src="{{ bfscript }}"></script>
         {{ /if }}
     </head>
 
     <body>
-        <nav class="navbar is-info" role="navigation" aria-label="main navigation">
+        <nav-menu class="navbar is-info" role="navigation" aria-label="main navigation">
             <div class="navbar-brand">
                 <!-- .is-active doesn't currently work under .navbar.is-info -->
                 <a class="navbar-item {{- if tags?.includes('main') }} has-background-dark has-text-info{{ /if }}" title="JoCo Book Club" href="/">
                     <i class="fa-duotone fa-solid fa-book-open-cover fa-2x"></i>
                 </a>
-                <a class="navbar-item" title="Upcoming Books" href="/#upcoming">
-                    <i class="fa-duotone fa-solid fa-book-sparkles"></i>
+                
+                <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false">
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
                 </a>
-                <a class="navbar-item" title="Current Ballot" href="/#ballot">
-                    <i class="fa-duotone fa-solid fa-box-ballot"></i>
-                </a>
-                <a class="navbar-item {{ if tags?.includes('previous') }} has-background-dark has-text-info{{ /if }}" title="Previous Books" href="/previous">
-                    <i class="fa-duotone fa-solid fa-books"></i>
-                </a>
-                <a class="navbar-item {{ if tags?.includes('ranking') }} has-background-dark has-text-info{{ /if }}" title="Current Rankings" href="/ranking">
-                    <i class="fa-duotone fa-solid fa-ballot"></i>
-                </a>
-                <a class="navbar-item {{ if tags?.includes('suggestion') }} has-background-dark has-text-info{{ /if }}" title="Suggestions" href="/suggestions">
-                    <i class="fa-duotone fa-solid fa-lightbulb"></i>
-                </a>
-                <login-button login="{{ "/login" |> url }}" passkey="{{ "/passkey" |> url }}" active="{{ if tags?.includes('login') }}true{{ else }}false{{ /if }}" style="display: contents;"></login-button>
             </div>
-        </nav>
+            <div class="navbar-menu">
+                <div class="navbar-start">
+                    <a class="navbar-item" title="Upcoming Books" href="/#upcoming">
+                        <i class="fa-duotone fa-solid fa-book-sparkles"></i>
+                        <span class="is-hidden-desktop">Upcoming Books</span>
+                    </a>
+                    <a class="navbar-item" title="Current Ballot" href="/#ballot">
+                        <i class="fa-duotone fa-solid fa-box-ballot"></i>
+                        <span class="is-hidden-desktop">Current Ballot</span>
+                    </a>
+                    <a class="navbar-item {{ if tags?.includes('previous') }} has-background-dark has-text-info{{ /if }}" title="Previous Books" href="/previous">
+                        <i class="fa-duotone fa-solid fa-books"></i>
+                        <span>Previous Books</span>
+                    </a>
+                    <a class="navbar-item {{ if tags?.includes('ranking') }} has-background-dark has-text-info{{ /if }}" title="Current Rankings" href="/ranking">
+                        <i class="fa-duotone fa-solid fa-ballot"></i>
+                        <span>Current Rankings</span>
+                    </a>
+                    <a class="navbar-item {{ if tags?.includes('suggestion') }} has-background-dark has-text-info{{ /if }}" title="Suggestions" href="/suggestions">
+                        <i class="fa-duotone fa-solid fa-lightbulb"></i>
+                        <span>Suggestions</span>
+                    </a>
+                    <div class="navbar-item has-dropdown is-hoverable">
+                        <a class="navbar-link">
+                            <i class="fa-duotone fa-solid fa-tag"></i>
+                            Tags
+                        </a>
+
+                        <div class="navbar-dropdown">
+                            {{ for tag of Object.keys(genre.tags) }}
+                                <a class="navbar-item {{ if tags?.includes(tag) }} has-background-dark has-text-info{{ /if }}" href="/tags/{{ tag }}" title="{{ genre.tags[tag].title }}">
+                                    <span class="icon {{ genre.tags[tag].iconClass }}"><i class="fa-duotone fa-solid {{ genre.tags[tag].icon }}"></i></span>
+                                    {{ genre.tags[tag].name ?? genre.tags[tag].title }}
+                                </a>
+                            {{ /for }}
+                        </div>
+                    </div>
+                    <div class="navbar-item has-dropdown is-hoverable">
+                        <a class="navbar-link">
+                            <i class="fa-duotone fa-solid fa-ellipsis-vertical"></i>
+                            More
+                        </a>
+
+                        <div class="navbar-dropdown">        
+                            <a class="navbar-item {{ if tags?.includes('rules') }} has-background-dark has-text-info{{ /if }}" title="Club Rules" href="/rules">
+                                <i class="fa-duotone fa-solid fa-scale-balanced"></i>
+                                <span>Club Rules</span>
+                            </a>
+                            <a class="navbar-item" href="https://github.com/WorldMaker/jocobookclub/" title="Contact">
+                                <i class="fa-duotone fa-solid fa-code-branch"></i>
+                                <span>Source Code</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="navbar-end">
+                    <login-button login="{{ "/login" |> url }}" passkey="{{ "/passkey" |> url }}" active="{{ if tags?.includes('login') }}true{{ else }}false{{ /if }}" style="display: contents;"></login-button>
+                </div>
+            </div>
+        </nav-menu>
 
         {{ content }}
     </body>

--- a/src/site/index.vto
+++ b/src/site/index.vto
@@ -19,7 +19,7 @@ tags: [main]
     </div>
 </section>
 
-<div class="fixed-grid has-3-cols">
+<div class="fixed-grid has-3-cols-desktop">
     <div class="grid">
         <section class="section cell is-col-span-2">
             <h1 class="title" id="upcoming"><span class="icon has-text-primary"><i class="fa-duotone fa-solid fa-book-sparkles"></i></span> Upcoming Club Reads</h1>
@@ -64,6 +64,7 @@ tags: [main]
         <a class="button" href="./ranking/"><span class="icon"><i class="fa-duotone fa-solid fa-ballot"></i></span><span>Current Rankings</span></a>
         <a class="button" href="./rules/"><span class="icon"><i class="fa-duotone fa-solid fa-scale-balanced"></i></span><span>Club Rules</span></a>
         <a class="button" href="./suggestions/"><span class="icon"><i class="fa-duotone fa-solid fa-lightbulb"></i></span><span>Suggestions</span></a>
+        <a class="button" href="https://github.com/WorldMaker/jocobookclub"><span class="icon"><i class="fa-duotone fa-solid fa-code-branch"></i></span><span>Source Code</span></a>
     </div>
 </footer>
 

--- a/src/site/rules.md
+++ b/src/site/rules.md
@@ -1,6 +1,7 @@
 ---
 title: Club Rules
 layout: page.vto
+tags: [rules]
 ---
 
 - One vote per round per person.

--- a/src/site/tags.page.ts
+++ b/src/site/tags.page.ts
@@ -4,7 +4,8 @@ interface TagInfo {
   iconClass: string
   icon: string
   title: string
-  tag: string
+  name?: string
+  description?: string
 }
 
 export default function* tagsPages({}: Lume.Data) {
@@ -12,6 +13,7 @@ export default function* tagsPages({}: Lume.Data) {
     yield {
       ...info as TagInfo,
       tag,
+      tags: ['tag', tag],
       layout: 'tag.vto',
       url: `/tags/${tag}/`,
     }


### PR DESCRIPTION
- Adds a "burger menu" for cleaner navigation on mobile
- Expands many of the menu items to include text labels, not just tool tips
- Use a couple drop-downs to add direct links to all the genre tag pages and an out of the way for the rules page and other meta links
- Fix upcoming column not having enough room in mobile
- Link to the GitHub page directly

Resolves #130
Resolves #119
Resolves #140
Resolves #124