### PR TITLE
Support Local Time component on Safari

### DIFF
--- a/src/bf/local-time.ts
+++ b/src/bf/local-time.ts
@@ -1,32 +1,39 @@
-export class LocalTimeComponent extends HTMLTimeElement {
+export class LocalTimeComponent extends HTMLElement {
   connectedCallback() {
-    const datetime = this.getAttribute('datetime')
-    if (datetime) {
-      if (globalThis.Temporal) {
-        const temporalDate = Temporal.ZonedDateTime.from(datetime)
-        const localTemporalDate = temporalDate.withTimeZone(
-          Temporal.Now.timeZoneId(),
-        )
-        this.textContent = localTemporalDate.toLocaleString(undefined, {
-          dateStyle: 'full',
-          timeStyle: 'long',
-        })
-        this.title = temporalDate.toLocaleString()
-        this.classList.add('has-background-info-dark')
-        return
-      }
-      const splitDatetime = datetime.split('[')
-      const date = new Date(splitDatetime[0])
-      if (date && !isNaN(date.getTime())) {
-        this.textContent = date.toLocaleString(undefined, {
-          dateStyle: 'full',
-          timeStyle: 'long',
-        })
-        this.title = datetime
-        this.classList.add('has-background-info-dark')
+    const timeElements = this.querySelectorAll('time[datetime]')
+    for (const timeElement of timeElements) {
+      const datetime = timeElement.getAttribute('datetime')
+      if (datetime) {
+        if (globalThis.Temporal) {
+          const temporalDate = Temporal.ZonedDateTime.from(datetime)
+          const localTemporalDate = temporalDate.withTimeZone(
+            Temporal.Now.timeZoneId(),
+          )
+          timeElement.textContent = localTemporalDate.toLocaleString(
+            undefined,
+            {
+              dateStyle: 'full',
+              timeStyle: 'long',
+            },
+          )
+          ;(timeElement as HTMLTimeElement).title = temporalDate
+            .toLocaleString()
+          timeElement.classList.add('has-background-info-dark')
+          continue
+        }
+        const splitDatetime = datetime.split('[')
+        const date = new Date(splitDatetime[0])
+        if (date && !isNaN(date.getTime())) {
+          timeElement.textContent = date.toLocaleString(undefined, {
+            dateStyle: 'full',
+            timeStyle: 'long',
+          })
+          ;(timeElement as HTMLTimeElement).title = datetime
+          timeElement.classList.add('has-background-info-dark')
+        }
       }
     }
   }
 }
 
-customElements.define('local-time', LocalTimeComponent, { extends: 'time' })
+customElements.define('local-time', LocalTimeComponent)

--- a/src/site/_includes/book-card.vto
+++ b/src/site/_includes/book-card.vto
@@ -51,7 +51,7 @@
             {{ if time }}
                 {{> const plainDate = Temporal.PlainDate.from({ year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() }) }}
                 {{> const zonedDateTime = plainDate.toPlainDateTime(time).toZonedDateTime(timezone ?? 'UTC') }}
-                <time class="block" is="local-time" datetime="{{ zonedDateTime.toString() }}">{{ zonedDateTime.toLocaleString('en-us', { dateStyle: 'full', timeStyle: 'long' }) }}</time>
+                <local-time><time class="block" datetime="{{ zonedDateTime.toString() }}">{{ zonedDateTime.toLocaleString('en-us', { dateStyle: 'full', timeStyle: 'long' }) }}</time></local-time>
             {{ else }}
                 <time class="block" datetime="{{ date.toISOString() }}">{{ date.toLocaleString('en-us', { dateStyle: 'medium' }) }}</time>
             {{ /if }}


### PR DESCRIPTION
Safari doesn't support extending native tags and may not end up supporting it, so switch to a simple wrapper tag