### PR TITLE
Temporarily shift Production API URLs while waiting for DNS

### DIFF
--- a/scripts/api/client.ts
+++ b/scripts/api/client.ts
@@ -3,6 +3,6 @@ import type apiApp from '@worldmaker/jocobookclub-api'
 import { hc } from 'npm:hono@^4.6.16/client'
 
 const overrideApiUrl = Deno.env.get('CLUB_API_URL')
-const apiUrl = overrideApiUrl ?? 'https://api.jocobook.club'
+const apiUrl = overrideApiUrl ?? 'https://jocobookclub-api.worldmaker.deno.net/'
 
 export const apiClient = hc<typeof apiApp>(apiUrl)

--- a/src/bf/client.ts
+++ b/src/bf/client.ts
@@ -2,7 +2,7 @@ import type apiApp from '@worldmaker/jocobookclub-api'
 import { hc } from 'hono/client'
 
 const overrideApiUrl = localStorage.getItem('override/api-url')
-const apiUrl = overrideApiUrl ?? 'https://api.jocobook.club'
+const apiUrl = overrideApiUrl ?? 'https://jocobookclub-api.worldmaker.deno.net/'
 if (overrideApiUrl) {
   console.warn(`Using overridden API URL: ${overrideApiUrl}`)
 }


### PR DESCRIPTION
Enough complaints that the site isn't working while waiting on Deno to verify the updated DNS records which themselves are updated enough for outage complaints.

This is the "Current" Deno Deploy Production URL.

I expect to switch it back once DNS and Deno Deploy's validation of DNS clear up.