### PR TITLE
Clean up Support Threshold to match Leaderboard logic

### DIFF
--- a/src/api/models/tally.test.ts
+++ b/src/api/models/tally.test.ts
@@ -55,7 +55,7 @@ describe('tally', () => {
       ballot,
       fakeUser,
       emptyPreferred,
-      1,
+      0,
     )
     expect(tally.count).toEqual(1)
     expect(tally.supports).toEqual([0, 0, 0, 1, 0])
@@ -79,7 +79,7 @@ describe('tally', () => {
       ballot,
       fakeUser,
       preferred,
-      1,
+      0,
     )
     expect(tally.count).toEqual(3)
     expect(tally.supports).toEqual([0, 0, 0, 3, 0])
@@ -103,7 +103,7 @@ describe('tally', () => {
       ballot,
       { ...fakeUser, canEmail: true, preferredName: 'User One' },
       preferred,
-      1,
+      0,
     )
     expect(tally.count).toEqual(3)
     expect(tally.supports).toEqual([0, 0, 0, 3, 0])

--- a/src/api/models/tally.ts
+++ b/src/api/models/tally.ts
@@ -9,9 +9,10 @@ export const EligibleBooks = z.array(z.string())
 
 export type EligibleBooks = z.infer<typeof EligibleBooks>
 
-// Allowed percentage of books at Rank 1 for a ballot to be counted, to
-// encourage people to rank more books
-const SupportThreshold = 1
+// Percent of books [0, 1] that must be supported for a ballot to count. This
+// is intended to filter people ranking very few books or "haters" avoiding
+// a rich distribution of books across available ranks
+const SupportThreshold = 0
 
 export const UserSupport = z.object({
   userId: UserId,
@@ -138,13 +139,12 @@ export function getTallyFromBallot(
     }
   }
 
-  const oneRanked = booksByRank.get(1)?.size ?? 0
-  const percentOneRanked = oneRanked / books.length
-  if (percentOneRanked >= supportThreshold) {
+  const supportPercent = supportedBooks / books.length
+  if (supportPercent < supportThreshold) {
     console.log(
       `Ballot for ${ballot.userId} fails support threshold, skipping`,
       {
-        percentOneRanked,
+        supportPercent,
         supportThreshold,
       },
     )

--- a/src/site/_vote-history/2026-06-12.json
+++ b/src/site/_vote-history/2026-06-12.json
@@ -4234,5 +4234,5 @@
     "14297982",
     "14046991"
   ],
-  "supportThreshold": 1
+  "supportThreshold": 0
 }


### PR DESCRIPTION
This fixes the "reversed percentage" problem, simplifies similar but different logic, and makes it easier to visualize threshold changes via the Leaderboard.

#238 #255